### PR TITLE
Minor fix loading terminal-kit

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var _ = require('lodash');
 var clui = require('clui');
-var terminal = require('terminal-kit').terminal();
+var terminal = require('terminal-kit').terminal;
 
 module.exports = function() {
 	this._progressObjects = {};


### PR DESCRIPTION
Hi,

I'm the author of the Node.js lib "terminal-kit".

At the begining of your code, when loading the lib, you should replace:
var terminal = require('terminal-kit').terminal();

... by:
var terminal = require('terminal-kit').terminal;

Actually, your first line do something similar to a console.log() with an empty string.
By luck, most of terminal-kit's methods return itself (this), that's why your code is working anyway.

Also I would be happy if you give me some feedbacks about the lib!

Was the documentation easy to understand?
Is the lib easy to use?
Does it meet your expectation?
Any bug?

Have a nice day!
Cédric Ronvel.
